### PR TITLE
Fix double free

### DIFF
--- a/ccc.c
+++ b/ccc.c
@@ -858,7 +858,6 @@ void edit_file()
         system(command);
         reset_prog_mode();  /* return to previous tty mode */
         refresh();          /* store the screen contents */
-        free(filename);
     }
 }
 


### PR DESCRIPTION
`char *filename` is a pointer to an object inside the arraylist. free is not needed here because there was nothing allocated.